### PR TITLE
fix abs() usage in jet.eta comparison

### DIFF
--- a/Analysis/AnalysisHelpers.py
+++ b/Analysis/AnalysisHelpers.py
@@ -30,7 +30,7 @@ def isGoodMuon(Lepton):
     
 def isGoodJet(jet):
     if jet.pt() < 25: return False
-    if abs(jet.eta() > 2.5): return False
+    if abs(jet.eta()) > 2.5: return False
     if jet.pt() < 50 and abs(jet.eta() < 2.4) and jet.jvf() < 0.5: return False
     return True
 


### PR DESCRIPTION
This PR fixes a logical error in AnalysisHelpers.py where the `abs()` function, which normally should be applied to `jet.eta` was applied to the boolean result of the comparison `jet.eta() < 2.4`.
The original line : `if jet.pt() < 50 and abs(jet.eta() < 2.4 ) and jet.jvf() < 0.5: return False`
Here is the corrected line : `if jet.pt() < 50 and abs(jet.eta()) < 2.4 and jet.jvf() < 0.5: return False`
